### PR TITLE
fixes #20: improve notification routing documentation

### DIFF
--- a/source/docs/1.0/usage/Notification-Routing.md
+++ b/source/docs/1.0/usage/Notification-Routing.md
@@ -1,8 +1,52 @@
 ## Notification routing
 
-This is how events are turned into notifications, and how notifications are routed to contacts:
+The animation below shows graphically how events are turned into
+notifications, and how notifications are routed to contacts. Further down, you
+can find a step-by-step description of routing:
 
 ![notification routing](/images/notification-routing.gif)
+
+## Details
+
+1. **Find failing events**. The event is discarded if ANY of the following are true:
+     * new check state is Ok
+     * entity/check is in scheduled or unscheduled maintenance
+     * current state duration for entity/check is less than the `initial_failure_delay` (default 30 sec, can be specified in the incoming event)
+     * time elapsed since last notification is less than `repeat_failure_delay` (default 60 sec, can be specified in the incoming event)
+
+2. **Find contacts interested in entity**
+     * Includes all the  [Contacts](/docs/1.0/jsonapi#contacts) listed in the event [Entity](/docs/1.0/jsonapi#entities)
+     * Includes all the contacts listed in the special entity with id 
+       [ALL](/docs/1.0/usage/Howto-Dynamic-Entity-Contact-Linking)
+
+3. **For each contact**
+  3. **Find the subset of applicable contact notification rules based on tags, severity,
+     time of day**. Starting with all the
+     [Notification Rules](/docs/1.0/jsonapi#notification-rules) for the contact,
+     we find those for which **all** of the following are true:
+      * Each `tag` in the rule is among the event tags. Note that
+        an event has two tags added automatically: the entity name, and the
+        check name.
+      * Each `regex_tag` in the rule matches at least one of the event tags.
+      * The rule has no `entities`, or the event entity is among the rule `entities`.
+      * Each `regex_entity` matches the event entity.
+      * At least one of the rule `time_restrictions` matches the event time.
+  
+  4. **Skip notification based on blackhole notification rules**.
+      * If any of the applicable contact notification rules found at previous step contains
+         `xxx_blackhole == true`, for the current event state `xxx`, we do not notify
+         the current contact.
+  
+  5. **Find the notifiable media types for the contact based on notification rules**.
+      * From the applicable contact notification rules found at previous step, get the
+         set of media types listed in the rules `xxx_media`, for the current event
+         state `xxx`.
+      * If there are no notifiable media types, we do not notify the current contact.
+     
+  6. **Discard the media types based on media notification intervals**.
+     * From the list of media types found at previous step, discard those
+       for which an alert has been sent for the current contact-entity-check
+       combination in the last media `interval`.
 
 #### Creating the above animation
 


### PR DESCRIPTION
This is my first attempt to understand and document how notification routing works in 1.x. Since Flapjack is primarily a notification routing engine, I think that this part needs to be documented clearly. 

Here are a few aspects that I am still unclear about:
* There are discrepancies between the animated git (which I have not changed) and my description. The animation says "delete media based on tags, severity, time of day". It seems that what is being deleted are the notification rules.
* The animation says "delete media based on blackholes". It seems that what is being deleted are the contacts. 
* The details of how the notification rule 'regex_entity' work do not make sense. If you have an array of those, one would expect that the event entity should match at least one of the 'regex_entity' (to generalize the handling of the 'entity'). Instead the code seems to match all 'regex_entity'
* We need a documentation for how time_restrictions work. 